### PR TITLE
FOOD-25 Add help option to return usage instructions

### DIFF
--- a/src/lib/SlackClient.py
+++ b/src/lib/SlackClient.py
@@ -58,8 +58,14 @@ class SlackClient:
 
         # the slash command wouldn't even be triggered without the "/lunch" but let's just do a sanity check
         if command['command'] == '/lunch':
+            if 'help' in command['text'].lower():
+                message = 'Chef Emay helps you decide on a lunch place based on a set list of available options ' \
+                          'nearby!\nAn example usage would be `/lunch recommend 3`. This will return a list of 3 ' \
+                          'randomly selected food locations.'
+                # not technically an error but we want to keep the message private to only the user
+                response_type = self.ERROR_RESPONSE_TYPE
             # app mention text should be in format: "recommend N", where N is the number of choices to return
-            if 'recommend' in command['text'].lower() and len(command['text'].split(' ')) == 2:
+            elif 'recommend' in command['text'].lower() and len(command['text'].split(' ')) == 2:
                 num_choices = command['text'].split(' ')[1]
                 try:
                     num_choices = int(num_choices)

--- a/tests/test_slack_client.py
+++ b/tests/test_slack_client.py
@@ -31,7 +31,7 @@ class TestSlackClient:
         slack_client = SlackClient()
         format_check = slack_client.check_command_format(command)
         assert format_check.keys() >= {'valid', 'message', 'response_type'}
-        assert format_check['valid'] == False
+        assert format_check['valid'] is False
         assert format_check['response_type'] == SlackClient.ERROR_RESPONSE_TYPE
         assert error_msg in format_check['message']
 
@@ -63,7 +63,14 @@ class TestSlackClient:
         }
         format_check = slack_client.check_command_format(command)
         assert format_check.keys() >= {'valid', 'message', 'response_type'}
-        assert format_check['valid'] == True
+        assert format_check['valid'] is True
+
+    def test_check_command_help(self, slack_client):
+        command = {
+            'command': '/lunch',
+            'text': 'help'
+        }
+        self.invalid_command_helper(command, 'An example usage would be')
 
     def test_check_command_format_invalid_command(self):
         command = {


### PR DESCRIPTION
#### What does this PR do?
Adds an option to return description of app and example usage.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@aaronilovici
@aperullo
@cjlange
@josephthweatt
@njbarber  
@pvargas
@rfding

#### How should this be tested? (List steps with links to updated documentation)
1. Run tests.
2. Verify.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes #25 

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests